### PR TITLE
Add focus-visible polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -923,6 +923,11 @@
         "path-exists": "^4.0.0"
       }
     },
+    "focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
+    },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "autoprefixer": "^10.2.6",
+    "focus-visible": "^5.2.0",
     "next": "10.2.3",
     "postcss": "^8.3.0",
     "react": "17.0.2",

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,5 +1,5 @@
 export default function Home() {
-  return (
-    <h1>Hello World!</h1>
-  )
+    return (
+        <h1>Hello World!</h1>
+    )
 }

--- a/styles/base/_base-elements.scss
+++ b/styles/base/_base-elements.scss
@@ -66,7 +66,7 @@ button {
     padding: 0;
     cursor: pointer;
 
-    // &:focus:not(.focus-visible) {
-    //     outline: none;
-    // }
+    &:focus:not(.focus-visible) {
+        outline: none;
+    }
 }


### PR DESCRIPTION
### Context
`:focus-visible` is a CSS pseudo selector that tells whether or not a focused element should actually have focus styling, depending on various heuristics like device type and usage of mouse/keyboard. 

This is important for UX of various scenarios, e.g:
- When we click a button but we don't want focus styles to persist.
- When, on mobile, we tap a button but we don't want focus styles to persist.

It doesn't have great browser support (view below), so I'm adding the polyfill for now. I believe this is crucial for any project I work on, so I'm adding it to the scaffold.  

### Browser Support
![focus-visible caniuse browser support](https://caniuse.bitsofco.de/image/css-focus-visible.jpg)